### PR TITLE
Add CatBoost BTC returns example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ htmlcov/
 # For SR
 secrets.yaml
 problems
+catboost_info/

--- a/examples/catboost_returns/README.md
+++ b/examples/catboost_returns/README.md
@@ -1,0 +1,24 @@
+# CatBoost Bitcoin Return Forecasting Example
+
+This example demonstrates how to use **OpenEvolve** to evolve a CatBoost model
+for predicting future Bitcoin returns. The dataset `BTC_30.csv` contains OHLCV
+records sampled every 30 minutes. The goal is to minimize validation RMSE when
+forecasting returns `horizon` bars into the future.
+
+## Files
+
+- `initial_program.py` – Starting CatBoost implementation inside an EVOLVE-BLOCK.
+- `evaluator.py` – Evaluation script computing RMSE and a `combined_score`.
+- `config.yaml` – OpenEvolve configuration with a `horizon` parameter.
+- `requirements.txt` – Python dependencies.
+
+## Running the Example
+
+```bash
+cd examples/catboost_returns
+python ../../openevolve-run.py initial_program.py evaluator.py --config config.yaml
+```
+
+OpenEvolve will evolve the code inside the EVOLVE-BLOCK to reduce RMSE on the
+validation split. The `horizon` value in `config.yaml` controls how many bars
+ahead to predict.

--- a/examples/catboost_returns/config.yaml
+++ b/examples/catboost_returns/config.yaml
@@ -1,0 +1,37 @@
+# Configuration for CatBoost return prediction example
+horizon: 10
+max_iterations: 50
+checkpoint_interval: 10
+log_level: "INFO"
+
+llm:
+  primary_model: "gpt-4o-mini"
+  primary_model_weight: 1.0
+  api_base: "https://api.openai.com/v1"
+  temperature: 0.7
+  top_p: 0.95
+  max_tokens: 4096
+
+database:
+  population_size: 20
+  archive_size: 5
+  num_islands: 2
+  elite_selection_ratio: 0.2
+  exploitation_ratio: 0.7
+  feature_dimensions: ["combined_score", "complexity"]
+
+evaluator:
+  timeout: 60
+  cascade_evaluation: false
+  parallel_evaluations: 1
+  use_llm_feedback: false
+
+prompt:
+  system_message: |
+    You are an expert machine learning engineer. Improve the CatBoost training
+    code inside the EVOLVE-BLOCK to minimize validation RMSE for Bitcoin return
+    forecasting over the specified horizon.
+  num_top_programs: 3
+  use_template_stochasticity: true
+
+diff_based_evolution: true

--- a/examples/catboost_returns/evaluator.py
+++ b/examples/catboost_returns/evaluator.py
@@ -1,0 +1,37 @@
+"""Evaluator for CatBoost return prediction example."""
+import importlib.util
+import os
+import yaml
+
+from openevolve.evaluation_result import EvaluationResult
+
+
+def _load_horizon(default: int = 1) -> int:
+    """Load horizon from config.yaml in the same directory."""
+    config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            cfg = yaml.safe_load(f) or {}
+        return int(cfg.get("horizon", default))
+    return default
+
+
+def evaluate(program_path: str) -> EvaluationResult:
+    """Run the program's train_model and return combined_score and rmse."""
+    horizon = _load_horizon()
+
+    spec = importlib.util.spec_from_file_location("program", program_path)
+    program = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(program)
+
+    if not hasattr(program, "train_model"):
+        return EvaluationResult(metrics={"combined_score": 0.0, "rmse": 0.0})
+
+    try:
+        result = program.train_model(horizon=horizon)
+        rmse = float(result.get("rmse", 0.0)) if isinstance(result, dict) else float(result)
+    except Exception as e:
+        return EvaluationResult(metrics={"combined_score": 0.0, "rmse": 0.0, "error": 1.0})
+
+    combined_score = 1.0 / (1.0 + rmse)
+    return EvaluationResult(metrics={"combined_score": combined_score, "rmse": rmse})

--- a/examples/catboost_returns/initial_program.py
+++ b/examples/catboost_returns/initial_program.py
@@ -1,0 +1,51 @@
+# EVOLVE-BLOCK-START
+"""
+CatBoost model for Bitcoin return prediction.
+
+This program loads BTC_30.csv and trains a CatBoostRegressor to predict
+future returns. The horizon parameter controls how many bars ahead the
+model forecasts returns.
+"""
+import pandas as pd
+import numpy as np
+from catboost import CatBoostRegressor
+
+
+def train_model(
+    horizon: int = 1,
+    test_fraction: float = 0.2,
+    iterations: int = 200,
+    depth: int = 6,
+    learning_rate: float = 0.1,
+):
+    """Train CatBoost on BTC_30.csv and return validation RMSE."""
+    df = pd.read_csv("BTC_30.csv")
+    df["return"] = df["close"].pct_change().shift(-horizon)
+    df = df.dropna().reset_index(drop=True)
+
+    features = df[["open", "high", "low", "close", "volume"]]
+    target = df["return"]
+
+    split_idx = int(len(df) * (1 - test_fraction))
+    X_train, X_valid = features.iloc[:split_idx], features.iloc[split_idx:]
+    y_train, y_valid = target.iloc[:split_idx], target.iloc[split_idx:]
+
+    model = CatBoostRegressor(
+        iterations=iterations,
+        depth=depth,
+        learning_rate=learning_rate,
+        loss_function="RMSE",
+        verbose=False,
+        random_seed=42,
+    )
+    model.fit(X_train, y_train, eval_set=(X_valid, y_valid), verbose=False)
+
+    preds = model.predict(X_valid)
+    rmse = float(np.sqrt(np.mean((preds - y_valid) ** 2)))
+    return {"rmse": rmse}
+
+# EVOLVE-BLOCK-END
+
+if __name__ == "__main__":
+    metrics = train_model()
+    print(metrics)

--- a/examples/catboost_returns/requirements.txt
+++ b/examples/catboost_returns/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+numpy
+catboost


### PR DESCRIPTION
## Summary
- add new example `catboost_returns` that trains a CatBoost model on `BTC_30.csv`
- evaluator reads `horizon` from config and reports `combined_score`
- config tuned for quick experimentation
- include README and requirements
- ignore CatBoost output directory

## Testing
- `python -m unittest discover tests` *(fails: AuthenticationError from OpenAI and other errors)*
- `python examples/catboost_returns/initial_program.py`
- `python openevolve-run.py examples/catboost_returns/initial_program.py examples/catboost_returns/evaluator.py --config examples/catboost_returns/config.yaml --iterations 1 --log-level INFO`

------
https://chatgpt.com/codex/tasks/task_e_68840e16e8ac832684a7c0170174b583