### PR TITLE
Fix evaluation failure metrics

### DIFF
--- a/examples/mlx_metal_kernel_opt/quick_benchmark_test.py
+++ b/examples/mlx_metal_kernel_opt/quick_benchmark_test.py
@@ -4,6 +4,10 @@ Quick Benchmark Test - Test the benchmark suite with a few key scenarios
 
 import os
 import sys
+import pytest
+
+# Skip the test if MLX is not installed
+pytest.importorskip("mlx.core")
 
 # Add current directory to path for local imports
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/openevolve/evaluator.py
+++ b/openevolve/evaluator.py
@@ -272,7 +272,9 @@ class Evaluator:
         logger.error(
             f"All evaluation attempts failed for program{program_id_str}. Last error: {str(last_exception)}"
         )
-        return {"error": 0.0}
+
+        # Return a consistent metric dict so feature dimensions always exist
+        return {"combined_score": 0.0, "rmse": 0.0, "error": 1.0}
 
     def _process_evaluation_result(self, result: Any) -> EvaluationResult:
         """

--- a/tests/test_evaluator_timeout.py
+++ b/tests/test_evaluator_timeout.py
@@ -304,7 +304,7 @@ def evaluate_stage3(program_path):
 
             # Should return error result after all retries fail
             self.assertIn("error", result)
-            self.assertEqual(result["error"], 0.0)
+            self.assertEqual(result["error"], 1.0)
 
         asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- ensure evaluator returns default metrics after all retries fail
- skip MLX benchmark test if `mlx` is missing
- update timeout tests for new error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884347b40d083269fdf3549bee617c7